### PR TITLE
fix: tabs not found if created with spaces in the name

### DIFF
--- a/client/src/components/Tab.tsx
+++ b/client/src/components/Tab.tsx
@@ -23,14 +23,15 @@ export default function Tab() {
   const { goals, tabs, isLoading } = state;
   const { tabName } = useParams();
 
-  // const normalizedTabName = decodeURIComponent(tabName).trim().toLowerCase();
-  const normalizedTabName = decodeURIComponent(tabName ?? "")
-    .trim()
-    .toLowerCase();
+  const normalizeName = (name) =>
+    decodeURIComponent(name ?? "")
+      .trim()
+      .toLowerCase()
+      .replace(/\s+/g, "-");
 
-  const tab = tabs.find(
-    (tab) => tab.name.trim().toLowerCase() === normalizedTabName
-  );
+  const normalizedTabName = normalizeName(tabName);
+
+  const tab = tabs.find((tab) => normalizeName(tab.name) === normalizedTabName);
 
   const tabGoals = tab ? goals.filter((goal) => goal.tab === tab.name) : [];
 


### PR DESCRIPTION
There was a bug that meant that spaces in tab names were being converted to dashes in the URL, but being removed from the front-end derived state, which meant tabs were not being found. This has now been squashed, so tabs will always be found.